### PR TITLE
Executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+*.out
+*.ll
+_build*

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main where
 
-import Parser
-import Ast
-import Sast
-import Semant
-import Codegen
+import Microc hiding (Parser)
 
 import Prelude hiding (FilePath)
-import Text.Megaparsec (runParser, parseTest')
 import Options.Applicative
 import Data.Semigroup ((<>))
 import Data.Maybe (fromMaybe)
@@ -19,7 +14,7 @@ import qualified Data.Text.Lazy as TL
 
 import LLVM.Pretty
 
-import Turtle
+import Turtle hiding (Parser)
 
 data Action = Ast | Sast | LLVM | Compile FilePath
 data Options = Options { action :: Action, infile :: FilePath, llc :: FilePath }

--- a/mcc.cabal
+++ b/mcc.cabal
@@ -17,14 +17,19 @@ extra-source-files:  README.md
 executable mcc
   hs-source-dirs:      src
   main-is:             Main.hs
+  other-modules:       Ast,
+                       Codegen,
+                       Parser,
+                       Sast,
+                       Scanner,
+                       Semant
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-unused-matches
   build-depends:       base >= 4.7 && < 5,
                        megaparsec >= 6.4.1,
                        mtl >= 2.2,
-                       recursion-schemes >= 5.0.2,
+                       -- recursion-schemes >= 5.0.2,
                        optparse-applicative,
-                       directory,
                        containers,
                        text,
                        llvm-hs-pure >= 6.1 && < 7,

--- a/mcc.cabal
+++ b/mcc.cabal
@@ -22,15 +22,9 @@ library
   build-depends:       base >= 4.7 && < 5,
                        megaparsec >= 6.4.1,
                        mtl >= 2.2,
-                       -- recursion-schemes >= 5.0.2,
-                       -- optparse-applicative,
                        containers,
                        text,
                        llvm-hs-pure >= 6.1 && < 7
-                       -- llvm-hs >= 6.1 && < 7,
-                       -- llvm-hs-pretty,
-                       -- turtle >= 0.5 && < 1.6
-
 
 executable mcc
   hs-source-dirs:      app
@@ -41,11 +35,10 @@ executable mcc
                        mcc,
                        megaparsec >= 6.4.1,
                        mtl >= 2.2,
-                       -- recursion-schemes >= 5.0.2,
                        optparse-applicative,
                        containers,
                        text,
                        llvm-hs-pure >= 6.1 && < 7,
-                       -- llvm-hs >= 6.1 && < 7,
+                       llvm-hs >= 6.1 && < 7,
                        llvm-hs-pretty,
                        turtle >= 0.5 && < 1.6

--- a/mcc.cabal
+++ b/mcc.cabal
@@ -14,18 +14,31 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md
 
-executable mcc
+library
   hs-source-dirs:      src
-  main-is:             Main.hs
-  other-modules:       Ast,
-                       Codegen,
-                       Parser,
-                       Sast,
-                       Scanner,
-                       Semant
+  exposed-modules:     Microc
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-unused-matches
   build-depends:       base >= 4.7 && < 5,
+                       megaparsec >= 6.4.1,
+                       mtl >= 2.2,
+                       -- recursion-schemes >= 5.0.2,
+                       -- optparse-applicative,
+                       containers,
+                       text,
+                       llvm-hs-pure >= 6.1 && < 7
+                       -- llvm-hs >= 6.1 && < 7,
+                       -- llvm-hs-pretty,
+                       -- turtle >= 0.5 && < 1.6
+
+
+executable mcc
+  hs-source-dirs:      app
+  main-is:             Main.hs
+  default-language:    Haskell2010
+  ghc-options:         -Wall -fno-warn-name-shadowing -fno-warn-unused-imports -fno-warn-unused-matches
+  build-depends:       base >= 4.7 && < 5,
+                       mcc,
                        megaparsec >= 6.4.1,
                        mtl >= 2.2,
                        -- recursion-schemes >= 5.0.2,
@@ -33,5 +46,6 @@ executable mcc
                        containers,
                        text,
                        llvm-hs-pure >= 6.1 && < 7,
+                       -- llvm-hs >= 6.1 && < 7,
                        llvm-hs-pretty,
                        turtle >= 0.5 && < 1.6

--- a/mcc.cabal
+++ b/mcc.cabal
@@ -28,5 +28,5 @@ executable mcc
                        containers,
                        text,
                        llvm-hs-pure >= 6.1 && < 7,
-                       llvm-hs-pretty
-                       --llvm-hs >= 6.1.1 && < 7
+                       llvm-hs-pretty,
+                       turtle >= 0.5 && < 1.6

--- a/src/Codegen.hs
+++ b/src/Codegen.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE StandaloneDeriving #-}
+-- {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+-- {-# LANGUAGE StandaloneDeriving #-}
 module Codegen where
 
 import qualified LLVM.AST.IntegerPredicate as IP
@@ -98,12 +98,12 @@ codegenSexpr sx =
   error $ "Internal error - semant failed. Invalid sexpr " ++ show sx
 
 codegenStatement :: (MonadState Env m, L.MonadIRBuilder m) => SStatement -> m ()
-codegenStatement (SExpr e) = codegenSexpr e >> return ()
+codegenStatement (SExpr e) = void $ codegenSexpr e
 codegenStatement (SReturn e) = codegenSexpr e >>= L.ret
 
 codegenStatement (SBlock ss) = mapM_ codegenStatement ss
 
-codegenStatement _ = error $ "If, for, and while WIP"
+codegenStatement _ = error "If, for, and while WIP"
 
 codegenFunc :: SFunction -> LLVM ()
 codegenFunc f = do
@@ -114,7 +114,7 @@ codegenFunc f = do
       body params = do
         _entry <- L.block `L.named` "entry"
         env <- get
-        _ <- forM args $ \(t, n) -> do
+        forM_ args $ \(t, n) -> do
           addr <- L.alloca t Nothing 0
           L.store addr 0 (AST.LocalReference t (fromString $ show n))
           modify $ M.insert (show n) addr

--- a/src/Microc.hs
+++ b/src/Microc.hs
@@ -1,0 +1,10 @@
+-- ReExport all submodules so that they are visible to whoever writes
+-- `import Microc`
+module Microc (module X) where
+
+import Microc.Ast     as X
+import Microc.Sast    as X
+import Microc.Scanner as X
+import Microc.Parser  as X
+import Microc.Semant  as X
+import Microc.Codegen as X

--- a/src/Microc/Ast.hs
+++ b/src/Microc/Ast.hs
@@ -1,4 +1,4 @@
-module Ast where
+module Microc.Ast where
 
 data Op = Add | Sub | Mult | Div | Equal | Neq | Less | Leq | Greater | Geq |
           And | Or deriving (Show, Eq)

--- a/src/Microc/Codegen.hs
+++ b/src/Microc/Codegen.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
--- {-# LANGUAGE GeneralizedNewtypeDeriving #-}
--- {-# LANGUAGE StandaloneDeriving #-}
 module Microc.Codegen (codegenProgram) where
 
 import qualified LLVM.AST.IntegerPredicate as IP

--- a/src/Microc/Codegen.hs
+++ b/src/Microc/Codegen.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 -- {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 -- {-# LANGUAGE StandaloneDeriving #-}
-module Codegen where
+module Microc.Codegen (codegenProgram) where
 
 import qualified LLVM.AST.IntegerPredicate as IP
 import qualified LLVM.AST.FloatingPointPredicate as FP
@@ -26,9 +26,9 @@ import Control.Monad.State
 import Control.Monad.Identity
 import Data.String (fromString)
 
-import qualified Semant
-import Sast
-import Ast (Type(..), Op(..), Uop(..), Function(..))
+import qualified Microc.Semant as Semant
+import Microc.Sast
+import Microc.Ast (Type(..), Op(..), Uop(..), Function(..))
 
 -- When using the IRBuilder, both functions and variables have the type Operand
 type Env = M.Map String AST.Operand

--- a/src/Microc/Parser.hs
+++ b/src/Microc/Parser.hs
@@ -1,7 +1,7 @@
-module Parser (programP) where
+module Microc.Parser (programP, runParser, parseTest') where
 
-import Ast
-import Scanner
+import Microc.Ast
+import Microc.Scanner
 import Text.Megaparsec
 import Text.Megaparsec.Char
 import Text.Megaparsec.Expr

--- a/src/Microc/Sast.hs
+++ b/src/Microc/Sast.hs
@@ -1,6 +1,6 @@
-module Sast where
+module Microc.Sast where
 
-import Ast
+import Microc.Ast
 
 type SExpr = (Type, SExpr')
 data SExpr' = 

--- a/src/Microc/Scanner.hs
+++ b/src/Microc/Scanner.hs
@@ -1,4 +1,4 @@
-module Scanner (Parser,
+module Microc.Scanner (Parser,
                 sc, 
                 symbol, 
                 parens, 

--- a/stack.yaml
+++ b/stack.yaml
@@ -36,7 +36,7 @@ resolver: lts-12.0
 # non-dependency (i.e. a user package), and its test suites and benchmarks
 # will not be run. This is useful for tweaking upstream packages.
 packages:
-- .
+- '.'
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 # extra-deps: []


### PR DESCRIPTION
Running `mcc tests/test-hello.mc` generates an executable `a.out` that correctly prints what it's supposed to. This PR also restructures the project into a library containing the scanner, parser, semantic checker, and code generator, as well as a separate executable that wires all of the library functions together and also calls `clang` and `llc` externally to generate machine code.